### PR TITLE
Add help type

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,12 @@ h: {
 }
 ```
 
-* `type`: Available types are: `boolean`, `range`, `number`, `string`.  Defaults to `string`.
+* `type`: Available types are: `boolean`, `range`, `number`, `string`, and `help`.  Defaults to `string`.
+
+    `help` is a special type that allows the switch to be executed even though
+    other paramters are required. Use case is to display a help message and
+    quit. This will bypass all other errors, so be sure to capture it. It
+    behaves like a `boolean`.
 
 * `description`: Description message that will be returned with usage information.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,6 +44,8 @@ exports.parse = function (definition, options) {
 
     var args = options.argv || process.argv.slice(2);
     var last = null;
+    var errors = [];
+    var help = false;
 
     for (i = 0, il = args.length; i < il; ++i) {
         var arg = args[i];
@@ -53,27 +55,35 @@ exports.parse = function (definition, options) {
 
             var char = arg[1];
             if (!char) {
-                return internals.formatError('Invalid empty \'-\' option');
+                errors.push(internals.formatError('Invalid empty \'-\' option'));
+                continue;
             }
 
             if (char === '-' && arg.length <= 2) {
-                return internals.formatError('Invalid empty \'--\' option');
+                errors.push(internals.formatError('Invalid empty \'--\' option'));
+                continue;
             }
 
             var opts = (char === '-' ? [arg.slice(2)] : arg.slice(1).split(''));
             for (var p = 0, pl = opts.length; p < pl; ++p) {
 
                 if (last) {
-                    return internals.formatError('Invalid option:', last.name, 'missing value');
+                    errors.push(internals.formatError('Invalid option:', last.name, 'missing value'));
+                    continue;
                 }
 
                 var opt = opts[p];
                 var def = keys[opt];
                 if (!def) {
-                    return internals.formatError('Unknown option:', opt);
+                    errors.push(internals.formatError('Unknown option:', opt));
+                    continue;
                 }
 
-                if (def.type === 'boolean') {
+                if (def.type === 'help') {
+                    flags[def.name] = true;
+                    help = true;
+                }
+                else if (def.type === 'boolean') {
                     flags[def.name] = true;
                 }
                 else {
@@ -93,7 +103,8 @@ exports.parse = function (definition, options) {
                     value = parseInt(arg, 10);
 
                     if (!Hoek.isInteger(value)) {
-                        return internals.formatError('Invalid value (non-number) for option:', last.name)
+                        errors.push(internals.formatError('Invalid value (non-number) for option:', last.name));
+                        continue;
                     }
                 }
             }
@@ -102,7 +113,8 @@ exports.parse = function (definition, options) {
                 last.valid &&
                 last.valid.indexOf(value) === -1) {
 
-                return internals.formatError('Invalid value for option:', last.name);
+                errors.push(internals.formatError('Invalid value for option:', last.name));
+                continue;
             }
 
             var name = last ? last.name : '_';
@@ -128,7 +140,7 @@ exports.parse = function (definition, options) {
         }
 
         if (def.require && flags[def.name] === undefined) {
-            return internals.formatError(definition);
+            errors.push(internals.formatError(definition));
         }
 
         if (def.alias) {
@@ -139,6 +151,8 @@ exports.parse = function (definition, options) {
             }
         }
     }
+
+    if (errors.length && !help) { return errors[0]; }
 
     return flags;
 };

--- a/test/index.js
+++ b/test/index.js
@@ -142,6 +142,25 @@ describe('parse()', function () {
         done();
     });
 
+    it('does not return message when required parameter is missing if type help is being executed', function (done) {
+
+        var line = '--try -q -h';
+        var definition = {
+            h: {
+                type: 'help'
+            },
+            b: {
+                type: 'number',
+                require: true
+            }
+        };
+
+        var argv = parse(line, definition);
+        expect(argv.h).to.equal(true);
+
+        done();
+    });
+
     it('returns error message when required parameter is missing', function (done) {
 
         var line = '-a';


### PR DESCRIPTION
Fixes #25

Here's a possible solution.

Another would be to also append the errors (if any) to the returned `args`.

let me know what you think
