### PR TITLE
Validate input arguments using Joi

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -331,8 +331,14 @@ internals.color = function (name, code, enabled) {
 
     if (enabled) {
         var color = '\u001b[' + code + 'm';
-        return function (text) { return color + text + '\u001b[0m'; };
+        return function colorFormat (text) {
+
+            return color + text + '\u001b[0m';
+        };
     }
 
-    return function (text) { return text; };
+    return function plainFormat (text) {
+
+        return text;
+    };
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,9 @@
 
 var Tty = require('tty');
 var Hoek = require('hoek');
+var Joi = require('joi');
 
+var Schemas = require('./schemas');
 
 // Declare internals
 
@@ -11,8 +13,12 @@ var internals = {};
 
 exports.parse = function (definition, options) {
 
+    Joi.assert(definition, Schemas.definition, 'Invalid definition:');
+    Joi.assert(options, Schemas.parseOptions, 'Invalid options argument:');
+
     var flags = {};
     var keys = {};
+    definition = Joi.validate(definition, Schemas.definition).value;
     options = options || {};
 
     var names = Object.keys(definition);
@@ -22,14 +28,9 @@ exports.parse = function (definition, options) {
         def.name = name;
         keys[name] = def;
         if (def.alias) {
-            var aliases = [].concat(def.alias);
-            for (var a = 0, al = aliases.length; a < al; ++a) {
-                keys[aliases[a]] = def;
+            for (var a = 0, al = def.alias.length; a < al; ++a) {
+                keys[def.alias[a]] = def;
             }
-        }
-
-        if (def.valid !== undefined && !Array.isArray(def.valid)) {
-            def.valid = [def.valid];
         }
 
         if (def.type === 'boolean' && def.default !== undefined) {
@@ -148,9 +149,8 @@ exports.parse = function (definition, options) {
         }
 
         if (def.alias) {
-            aliases = [].concat(def.alias);
-            for (var d = 0, dl = aliases.length; d < dl; ++d) {
-                var alias = aliases[d];
+            for (var d = 0, dl = def.alias.length; d < dl; ++d) {
+                var alias = def.alias[d];
                 flags[alias] = flags[def.name];
             }
         }
@@ -169,7 +169,11 @@ exports.usage = function (definition, usage, options) {
         usage = '';
     }
 
-    options = options || { colors: null };
+    Joi.assert(definition, Schemas.definition, 'Invalid definition:');
+    Joi.assert(options, Schemas.usageOptions, 'Invalid options argument:');
+
+    definition = Joi.validate(definition, Schemas.definition).value;
+    options = Joi.validate(options || { colors: null }, Schemas.usageOptions).value;
     var color = internals.colors(options.colors);
     var output = usage ? 'Usage: ' + usage + '\n\n' : '\n';
     var col1 = ['Options:'];
@@ -222,13 +226,12 @@ internals.formatError = function (definition) {
 };
 
 
-internals.getShortName = function (shortName, alias) {
+internals.getShortName = function (shortName, aliases) {
 
-    if (!alias) {
+    if (!aliases) {
         return shortName;
     }
 
-    var aliases = [].concat(alias);
     for (var i = 0, il = aliases.length; i < il; ++i) {
         if (aliases[i] && aliases[i].length < shortName.length) {
             shortName = aliases[i];

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -1,0 +1,28 @@
+// Load modules
+
+var Joi = require('joi');
+
+
+// Declare internals
+
+var internals = {
+    validKeyRegex: /^[a-zA-Z0-9][a-zA-Z0-9-]*$/
+};
+
+
+exports.definition = Joi.object({}).pattern(internals.validKeyRegex, Joi.object({
+    alias: Joi.array().items(Joi.string().allow('')).single(),
+    type: Joi.string().valid(['boolean', 'range', 'number', 'string', 'help']).default('string'),
+    description: Joi.string(),
+    require: Joi.boolean(),
+    default: Joi.any(),
+    valid: Joi.array().items(Joi.any()).single()
+}));
+
+exports.parseOptions = Joi.object({
+    argv: Joi.array().items(Joi.string())
+});
+
+exports.usageOptions = Joi.object({
+    colors: Joi.boolean().allow(null)
+});

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "node": ">=0.10.30"
   },
   "dependencies": {
-    "hoek": "2.x.x"
+    "hoek": "2.x.x",
+    "joi": "6.x.x"
   },
   "devDependencies": {
     "lab": "5.x.x",

--- a/test/index.js
+++ b/test/index.js
@@ -24,13 +24,7 @@ describe('parse()', function () {
 
         var orig = process.argv;
         process.argv = [].concat('ignore', 'ignore', line.split(' '));
-        var result = null;
-        try {
-            result = Bossy.parse(definition, options);
-        }
-        catch (err) {
-            result = err;
-        }
+        var result = Bossy.parse(definition, options);
         process.argv = orig;
         return result;
     };
@@ -411,6 +405,49 @@ describe('parse()', function () {
 
         var argv = parse(line, definition);
         expect(argv.message).to.contain('Unknown option: b');
+
+        done();
+    });
+
+    it('throws on invalid input ', function (done) {
+
+        var line = '-a 0 -b';
+
+        expect(function () {
+
+            var definition = {
+                a: {
+                    unknown: true
+                }
+            };
+
+            parse(line, definition);
+        }).to.throw(Error, /^Invalid definition/);
+
+        expect(function () {
+
+            var definition = {
+                a: {
+                    type: 'unknown'
+                }
+            };
+
+            parse(line, definition);
+        }).to.throw(Error, /^Invalid definition/);
+
+        expect(function () {
+
+            var definition = {
+                '!!': {}
+            };
+
+            parse(line, definition);
+        }).to.throw(Error, /^Invalid definition/);
+
+        expect(function () {
+
+            parse(line, {}, { args: ['-c'] });
+        }).to.throw(Error, /^Invalid options argument/);
 
         done();
     });


### PR DESCRIPTION
This enables most function argument errors to be caught at development time.

I have tried to accommodate the existing usage in the schemas, and tested that the `lab` module, which uses `bossy`, still pass all tests.

Note that validation failures will result in thrown `Error`s. I'd say this is a breaking change.