### PR TITLE
Show default value when printing options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -213,6 +213,10 @@ exports.usage = function (definition, usage, options) {
         }
 
         var formattedDesc = def.description ? color.gray(def.description) : '';
+        if (def.default) {
+            formattedDesc += formattedDesc.length ? ' ' : '';
+            formattedDesc += color.gray('(' + def.default + ')');
+        }
         if (def.require) {
             formattedDesc += formattedDesc.length ? ' ' : '';
             formattedDesc += color.yellow('(required)');

--- a/test/index.js
+++ b/test/index.js
@@ -750,4 +750,35 @@ describe('usage()', function () {
         expect(result).to.contain('-c, --code');
         done();
     });
+
+    it('formatted usage message orders shows default values', function (done) {
+
+        var definition = {
+            aa: {
+                type: 'number',
+                description: 'This needs a number'
+            },
+            b: {
+                alias: 'beta',
+                description: 'Description for b',
+                default: 'b'
+            },
+            code: {
+                alias: 'c',
+                default: 'c'
+            },
+            d: {
+                alias: ['']
+            }
+
+        };
+
+        var result = Bossy.usage(definition);
+        expect(result).to.contain('-a');
+        expect(result).to.contain('-b, --beta');
+        expect(result).to.contain('(b)');
+        expect(result).to.contain('-c, --code');
+        expect(result).to.contain('(c)');
+        done();
+    });
 });


### PR DESCRIPTION
This PR adds the default option in grey after the argument description.

```
Options:

  -c, --currency       currency (eur)
```