### PR TITLE
show valid options in error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -119,7 +119,12 @@ exports.parse = function (definition, options) {
                 last.valid &&
                 last.valid.indexOf(value) === -1) {
 
-                errors.push(internals.formatError('Invalid value for option:', last.name));
+                const validValues = [];
+                for (let j = 0; j < last.valid.length; ++j) {
+                    const valid = last.valid[j];
+                    validValues.push(`'${valid}'`);
+                }
+                errors.push(internals.formatError('Invalid value for option:', last.name, '(valid: ' + validValues.join(',') + ')'));
                 continue;
             }
 

--- a/test/index.js
+++ b/test/index.js
@@ -174,6 +174,25 @@ describe('parse()', () => {
         done();
     });
 
+    it('returns list of valid options for multple options', (done) => {
+
+        const line = '-a rezero';
+        const definition = {
+            a: {
+                type: 'string',
+                valid: ['steins;gate','erased','death note']
+            }
+        };
+
+        const argv = parse(line, definition);
+        expect(argv.message).to.include('steins;gate');
+        expect(argv.message).to.include('erased');
+        expect(argv.message).to.include('death note');
+        expect(argv).to.be.instanceof(Error);
+
+        done();
+    });
+
     it('returns error message when an unknown argument is used', (done) => {
 
         const line = '-ac';


### PR DESCRIPTION
* Fixes #44 

This doesn't actually show the valid options in the help message. In retrospect I think that's too noisy, however it shows the valid options in the error instead:

`Invalid value for option: a (valid: 'steins;gate','erased','death note')`