### PR TITLE
Implement negation of boolean arguments

### DIFF
--- a/API.md
+++ b/API.md
@@ -65,6 +65,10 @@ h: {
 
 * `type`: Available types are: `boolean`, `range`, `number`, `string`, and `help`.  Defaults to `string`.
 
+    The `boolean` type may be negated by passing its argument prefixed with `no-`.
+    For example, if the command line argument is named `color` then `--color` would
+    ensure the boolean is `true` and `--no-color` would ensure it is `false`.
+
     `help` is a special type that allows the switch to be executed even though
     other paramters are required. Use case is to display a help message and
     quit. This will bypass all other errors, so be sure to capture it. It

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,5 @@
-Copyright (c) 2014-2020, Sideway Inc, and project contributors  
-Copyright (c) 2014, Walmart.  
+Copyright (c) 2014-2021, Sideway Inc, and project contributors
+Copyright (c) 2014, Walmart.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,5 @@
-Copyright (c) 2014-2021, Sideway Inc, and project contributors
+Copyright (c) 2014-2021, Project contributors
+Copyright (c) 2014-2020, Sideway Inc
 Copyright (c) 2014, Walmart.
 All rights reserved.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -74,18 +74,16 @@ exports.parse = function (definition, options) {
 
                 const opt = opts[j];
 
-                let def;
                 let booleanNegationDef;
 
                 if (opt.startsWith('no-')) {
                     const maybeDef = keys[opt.replace('no-', '')];
                     if (maybeDef && maybeDef.type === 'boolean') {
-                        def = maybeDef;
                         booleanNegationDef = maybeDef;
                     }
                 }
 
-                def = def || keys[opt];
+                const def = keys[opt] || booleanNegationDef;
 
                 if (!def) {
                     errors.push(internals.formatError('Unknown option:', opt));

--- a/lib/index.js
+++ b/lib/index.js
@@ -73,7 +73,20 @@ exports.parse = function (definition, options) {
                 }
 
                 const opt = opts[j];
-                const def = keys[opt];
+
+                let def;
+                let booleanNegationDef;
+
+                if (opt.startsWith('no-')) {
+                    const maybeDef = keys[opt.replace('no-', '')];
+                    if (maybeDef && maybeDef.type === 'boolean') {
+                        def = maybeDef;
+                        booleanNegationDef = maybeDef;
+                    }
+                }
+
+                def = def || keys[opt];
+
                 if (!def) {
                     errors.push(internals.formatError('Unknown option:', opt));
                     continue;
@@ -84,7 +97,7 @@ exports.parse = function (definition, options) {
                     help = true;
                 }
                 else if (def.type === 'boolean') {
-                    flags[def.name] = true;
+                    flags[def.name] = def !== booleanNegationDef;
                 }
                 else if (def.type === 'number' &&
                     opts.length > 1) {
@@ -114,7 +127,7 @@ exports.parse = function (definition, options) {
                 }
 
                 if (last.valid &&
-                    last.valid.indexOf(value) === -1) {
+                    !last.valid.includes(value)) {
 
                     const validValues = [];
                     for (let j = 0; j < last.valid.length; ++j) {

--- a/test/index.js
+++ b/test/index.js
@@ -314,6 +314,21 @@ describe('parse()', () => {
         expect(argv).to.equal({ a: false });
     });
 
+    it('allows a boolean that has already been passed to be negated and vice-versa', () => {
+
+        const definition = {
+            a: {
+                type: 'boolean'
+            }
+        };
+
+        const argv1 = parse('-a --no-a', definition);
+        expect(argv1).to.equal({ a: false });
+
+        const argv2 = parse('--no-a -a', definition);
+        expect(argv2).to.equal({ a: true });
+    });
+
     it('doesn\'t assume "no-" to denote boolean negation', () => {
 
         const line = '--no-a';
@@ -331,7 +346,7 @@ describe('parse()', () => {
 
         const line = '--no-a';
         const definition = {
-            'a': {
+            a: {
                 type: 'string'
             }
         };
@@ -345,7 +360,7 @@ describe('parse()', () => {
 
         const line = '--no-a str';
         const definition = {
-            'a': {
+            a: {
                 type: 'boolean',
                 default: true
             },

--- a/test/index.js
+++ b/test/index.js
@@ -300,6 +300,47 @@ describe('parse()', () => {
         expect(argv).to.equal({ a: null, _: [''] });
     });
 
+    it('allows a boolean to be negated', () => {
+
+        const line = '--no-a';
+        const definition = {
+            a: {
+                type: 'boolean',
+                default: true
+            }
+        };
+
+        const argv = parse(line, definition);
+        expect(argv).to.equal({ a: false });
+    });
+
+    it('doesn\'t assume "no-" to denote boolean negation', () => {
+
+        const line = '--no-a';
+        const definition = {
+            'no-a': {
+                type: 'boolean'
+            }
+        };
+
+        const argv = parse(line, definition);
+        expect(argv).to.equal({ 'no-a': true });
+    });
+
+    it('only negates booleans', () => {
+
+        const line = '--no-a';
+        const definition = {
+            'a': {
+                type: 'string'
+            }
+        };
+
+        const argv = parse(line, definition);
+        expect(argv).to.be.instanceof(Error);
+        expect(argv.message).to.contain('Unknown option: no-a');
+    });
+
     it('allows custom argv to be passed in options in place of process.argv', () => {
 
         let argv = ['-a', '1-2,5'];

--- a/test/index.js
+++ b/test/index.js
@@ -341,6 +341,23 @@ describe('parse()', () => {
         expect(argv.message).to.contain('Unknown option: no-a');
     });
 
+    it('prefers explicit argument to boolean negation in a conflict', () => {
+
+        const line = '--no-a str';
+        const definition = {
+            'a': {
+                type: 'boolean',
+                default: true
+            },
+            'no-a': {
+                type: 'string'
+            }
+        };
+
+        const argv = parse(line, definition);
+        expect(argv).to.equal({ a: true, 'no-a': 'str' });
+    });
+
     it('allows custom argv to be passed in options in place of process.argv', () => {
 
         let argv = ['-a', '1-2,5'];


### PR DESCRIPTION
This PR implements the the ability to negate boolean command line arguments.  This uses a common convention of supporting boolean arguments prefixed by `no-`.  You will find this convention used in the git CLI, for example, and supported by other CLI parsing libraries such as yargs.  To illustrate: if the command line argument is named `color` then `--color` would ensure the boolean is `true` and `--no-color` would ensure it is `false`.