### PR TITLE
Implement object argument type

### DIFF
--- a/API.md
+++ b/API.md
@@ -63,7 +63,12 @@ h: {
 }
 ```
 
-* `type`: Available types are: `boolean`, `range`, `number`, `string`, and `help`.  Defaults to `string`.
+* `type`: Available types are: `boolean`, `range`, `number`, `string`, `object`, and `help`.  Defaults to `string`.
+
+    The `object` type allows building an object using command line arguments that utilize
+    dot-separated (`.`) paths, and optionally JSON. For example, an object argument named
+    `pet` might be built from `--pet '{ "type": "dog" }' --pet.name Maddie`, resulting in
+    the parsing output `{ pet: { type: 'dog', name: 'Maddie' } }`.
 
     `help` is a special type that allows the switch to be executed even though
     other paramters are required. Use case is to display a help message and

--- a/API.md
+++ b/API.md
@@ -64,19 +64,19 @@ line argument.  Each argument key supports the following properties:
     }
     ```
 
-* `type`: Available types are: `boolean`, `range`, `number`, `string`, `object`, and `help`.  Defaults to `string`.
+* `type`: Available types are: `boolean`, `range`, `number`, `string`, `json`, and `help`.  Defaults to `string`.
 
     `help` is a special type that allows the switch to be executed even though
     other paramters are required. Use case is to display a help message and
     quit. This will bypass all other errors, so be sure to capture it. It
     behaves like a `boolean`.
 
-    The `object` type allows building an object using command line arguments that utilize
-    dot-separated (`.`) paths, and optionally JSON. For example, an object argument named
+    The `json` type allows building an object using command line arguments that utilize
+    dot-separated (`.`) paths and JSON values. For example, an object argument named
     `pet` might be built from `--pet '{ "type": "dog" }' --pet.name Maddie`, resulting in
     the parsing output `{ pet: { type: 'dog', name: 'Maddie' } }`.  The contents of the
     flags are deeply merged together in the order they were specified.  Additionally,
-    JSON primtives (i.e. `null`, booleans, and numbers) are treated as strings by default,
+    JSON primitives (i.e. `null`, booleans, and numbers) are treated as strings by default,
     though this behavior may be controlled with the `parsePrimitives` option documented
     below.  The following example demonstrates the default behavior:
 
@@ -91,7 +91,7 @@ line argument.  Each argument key supports the following properties:
     ```
 
 * `multiple` : Boolean to indicate if the same argument can be provided multiple times. If true, the parsed value
-will always be an array of `type`'s. Defaults to `false`. Does not apply to `object` type arguments.
+will always be an array of `type`'s. Defaults to `false`. Does not apply to `json` type arguments.
 
 * `description`: Description message that will be returned with usage information.
 
@@ -99,6 +99,6 @@ will always be an array of `type`'s. Defaults to `false`. Does not apply to `obj
 
 * `default`: A default value to assign to the argument if its not provided as an argument.
 
-* `valid`: A value or array of values that the argument is allowed to equal. Does not apply to `object` type arguments.
+* `valid`: A value or array of values that the argument is allowed to equal. Does not apply to `json` type arguments.
 
-* `parsePrimitives`: When `true`, arguments of the `object` type will parse JSON primitives rather than treat them as strings.  For example, `--pet.name null` will result in the output `{ pet: { name: 'null' } }` by default.  However, when `parsePrimitives` is `true`, the same input would result in the output `{ pet: { name: null } }`.  The same applies for other JSON primitives too, i.e. booleans and numbers.  When this option is `true`, users may represent string values as JSON in order to avoid ambiguity, e.g. `--pet.name '"null"'`.  It's recommended that applications using this option document the behavior for their users.
+* `parsePrimitives`: When `true`, arguments of the `json` type will parse JSON primitives rather than treat them as strings.  For example, `--pet.name null` will result in the output `{ pet: { name: 'null' } }` by default.  However, when `parsePrimitives` is `true`, the same input would result in the output `{ pet: { name: null } }`.  The same applies for other JSON primitives too, i.e. booleans and numbers.  When this option is `true`, users may represent string values as JSON in order to avoid ambiguity, e.g. `--pet.name '"null"'`.  It's recommended that applications using this option document the behavior for their users.

--- a/API.md
+++ b/API.md
@@ -57,26 +57,41 @@ The definition object should be structured with each object key representing the
 line argument.  Each argument key supports the following properties:
 
 * `alias`: A string or array of strings that can also be used as the argument name.  For example:
-```
-h: {
-    alias: 'help'
-}
-```
+
+    ```js
+    h: {
+        alias: 'help'
+    }
+    ```
 
 * `type`: Available types are: `boolean`, `range`, `number`, `string`, `object`, and `help`.  Defaults to `string`.
-
-    The `object` type allows building an object using command line arguments that utilize
-    dot-separated (`.`) paths, and optionally JSON. For example, an object argument named
-    `pet` might be built from `--pet '{ "type": "dog" }' --pet.name Maddie`, resulting in
-    the parsing output `{ pet: { type: 'dog', name: 'Maddie' } }`.
 
     `help` is a special type that allows the switch to be executed even though
     other paramters are required. Use case is to display a help message and
     quit. This will bypass all other errors, so be sure to capture it. It
     behaves like a `boolean`.
 
+    The `object` type allows building an object using command line arguments that utilize
+    dot-separated (`.`) paths, and optionally JSON. For example, an object argument named
+    `pet` might be built from `--pet '{ "type": "dog" }' --pet.name Maddie`, resulting in
+    the parsing output `{ pet: { type: 'dog', name: 'Maddie' } }`.  The contents of the
+    flags are deeply merged together in the order they were specified.  Additionally,
+    JSON primtives (i.e. `null`, booleans, and numbers) are treated as strings by default,
+    though this behavior may be controlled with the `parsePrimitives` option documented
+    below.  The following example demonstrates the default behavior:
+
+    ```sh
+    # CLI Input
+    create-pet --pet.type kangaroo --pet.legs 2 --pet.mammal true \
+               --pet '{ "name": "Maddie", "type": "dog" }' --pet.legs 4
+    ```
+    ```js
+    // Parsing output
+    { pet: { name: 'Maddie', type: 'dog', legs: '4', mammal: 'true' } }
+    ```
+
 * `multiple` : Boolean to indicate if the same argument can be provided multiple times. If true, the parsed value
-will always be an array of `type`'s. Defaults to `false`.
+will always be an array of `type`'s. Defaults to `false`. Does not apply to `object` type arguments.
 
 * `description`: Description message that will be returned with usage information.
 
@@ -84,4 +99,6 @@ will always be an array of `type`'s. Defaults to `false`.
 
 * `default`: A default value to assign to the argument if its not provided as an argument.
 
-* `valid`: A value or array of values that the argument is allowed to equal.
+* `valid`: A value or array of values that the argument is allowed to equal. Does not apply to `object` type arguments.
+
+* `parsePrimitives`: When `true`, arguments of the `object` type will parse JSON primitives rather than treat them as strings.  For example, `--pet.name null` will result in the output `{ pet: { name: 'null' } }` by default.  However, when `parsePrimitives` is `true`, the same input would result in the output `{ pet: { name: null } }`.  The same applies for other JSON primitives too, i.e. booleans and numbers.  When this option is `true`, users may represent string values as JSON in order to avoid ambiguity, e.g. `--pet.name '"null"'`.  It's recommended that applications using this option document the behavior for their users.

--- a/API.md
+++ b/API.md
@@ -50,6 +50,33 @@ include the usage value formatted at the top of the message.
 Options accepts the following keys:
 * `colors` - Determines if colors are enabled when formatting usage.  Defaults to whatever TTY supports.
 
+### `object(name, parsed)`
+
+Un-flattens dot-separated arguments based at `name` from `Bossy.parse()`'s output into an object.
+
+```js
+const Bossy = require('@hapi/bossy');
+
+const definition = {
+    'pet.name': {
+        type: 'string'
+    },
+    'pet.age': {
+        type: 'number'
+    }
+};
+
+// Example CLI args: --pet.name Maddie --pet.age 5
+
+const parsed = Bossy.parse(definition);     // { 'pet.name': 'Maddie', 'pet.age': 5 }
+
+if (parsed instanceof Error) {
+    console.error(parsed.message);
+    return;
+}
+
+const pet = Bossy.object('pet', parsed);    // { name: 'Maddie', age: 5 }
+```
 
 ## Definition Object
 
@@ -81,7 +108,7 @@ line argument.  Each argument key supports the following properties:
     below.  The following example demonstrates the default behavior:
 
     ```sh
-    # CLI Input
+    # CLI input
     create-pet --pet.type kangaroo --pet.legs 2 --pet.mammal true \
                --pet '{ "name": "Maddie", "type": "dog" }' --pet.legs 4
     ```

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,5 @@
-Copyright (c) 2014-2020, Sideway Inc, and project contributors  
-Copyright (c) 2014, Walmart.  
+Copyright (c) 2014-2021, Sideway Inc, and project contributors
+Copyright (c) 2014, Walmart.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,5 @@
-Copyright (c) 2014-2021, Sideway Inc, and project contributors
+Copyright (c) 2014-2021, Project contributors
+Copyright (c) 2014-2020, Sideway Inc
 Copyright (c) 2014, Walmart.
 All rights reserved.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -141,6 +141,8 @@ exports.parse = function (definition, options) {
 
                 if (last.def.type === 'object') {
 
+                    const stringValue = value;
+
                     try {
                         value = Bourne.parse(value, {   // E.g. { x }
                             protoAction: 'remove'
@@ -149,6 +151,11 @@ exports.parse = function (definition, options) {
                     catch (err) {
                         // If the input doesn't look like JSON, we'll ignore that and treat it as a string
                         Bounce.ignore(err, SyntaxError);
+                    }
+
+                    if (!last.def.parsePrimitives && (!value || typeof value !== 'object')) {
+                        // When receiving JSON that parses to a non-object, treat it as a string, i.e. numbers, true, false, null.
+                        value = stringValue;
                     }
 
                     last.opt.split('.')                 // E.g. [name, lvl1, lvl2]

--- a/lib/index.js
+++ b/lib/index.js
@@ -142,11 +142,12 @@ exports.parse = function (definition, options) {
                 if (last.def.type === 'object') {
 
                     try {
-                        value = Bourne.parse(value, {   // E.g. { x }
-                            protoAction: 'remove'
-                        });
+                        // Value here is dirty until the Bourne.scan() below:
+                        // do not merge it into any other object to prevent proto poisoning.
+                        value = JSON.parse(value);      // E.g. { x }
                     }
                     catch (err) {
+                        // If the input doesn't look like JSON, we'll ignore that and treat it as a string
                         Bounce.ignore(err, SyntaxError);
                     }
 
@@ -162,6 +163,8 @@ exports.parse = function (definition, options) {
                         errors.push(internals.formatError('Invalid value for option:', last.def.name, '(must be an object or array)'));
                         continue;
                     }
+
+                    Bourne.scan(value, { protoAction: 'remove' });
                 }
             }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -158,13 +158,7 @@ exports.parse = function (definition, options) {
                         value = stringValue;
                     }
 
-                    last.opt.split('.')                 // E.g. [name, lvl1, lvl2]
-                        .slice(1)                       // E.g. [lvl1, lvl2]
-                        .reverse()                      // E.g. [lvl2, lvl1]
-                        .forEach((key) => {             // E.g. { x } --> { lvl2: { x } } --> { lvl1: { lvl2: { x } } }
-
-                            value = { [key]: value };
-                        });
+                    value = internals.valueAtArgPath(last.opt, value);
 
                     if (!value || typeof value !== 'object') {
                         errors.push(internals.formatError('Invalid value for option:', last.def.name, '(must be an object or array)'));
@@ -293,6 +287,23 @@ exports.usage = function (definition, usage, options) {
     }
 
     return output + internals.formatColumns(col1, col2);
+};
+
+
+exports.object = (opt, parsed) => {
+
+    Hoek.assert(!opt.includes('.'), `Cannot build an object at a deep path: ${opt} (contains a dot)`);
+
+    const initial = parsed.hasOwnProperty(opt) ? parsed[opt] : {};
+    const depth = (path) => path.split('.').length;
+
+    return Object.entries(parsed)
+        .filter(([key]) => key.startsWith(`${opt}.`))
+        .sort(([keyA], [keyB]) => depth(keyA) - depth(keyB)) // Shallow to deep
+        .reduce((collect, [key, val]) => {
+
+            return Hoek.applyToDefaults(collect, internals.valueAtArgPath(key, val));
+        }, initial);
 };
 
 
@@ -431,4 +442,17 @@ internals.color = function (name, code, enabled) {
 
         return text;
     };
+};
+
+internals.valueAtArgPath = (path, value) => {
+
+    path.split('.')                     // E.g. [name, lvl1, lvl2]
+        .slice(1)                       // E.g. [lvl1, lvl2]
+        .reverse()                      // E.g. [lvl2, lvl1]
+        .forEach((key) => {             // E.g. { x } --> { lvl2: { x } } --> { lvl1: { lvl2: { x } } }
+
+            value = { [key]: value };
+        });
+
+    return value;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -142,9 +142,9 @@ exports.parse = function (definition, options) {
                 if (last.def.type === 'object') {
 
                     try {
-                        // Value here is dirty until the Bourne.scan() below:
-                        // do not merge it into any other object to prevent proto poisoning.
-                        value = JSON.parse(value);      // E.g. { x }
+                        value = Bourne.parse(value, {   // E.g. { x }
+                            protoAction: 'remove'
+                        });
                     }
                     catch (err) {
                         // If the input doesn't look like JSON, we'll ignore that and treat it as a string
@@ -164,6 +164,7 @@ exports.parse = function (definition, options) {
                         continue;
                     }
 
+                    // Necessary to protect from prototype poisoning in dot-separated path e.g. `--x.__proto__.y 1`
                     Bourne.scan(value, { protoAction: 'remove' });
                 }
             }

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,7 +36,7 @@ exports.parse = function (definition, options) {
             }
         }
 
-        if ((def.type === 'boolean' || def.type === 'object') && def.default !== undefined) {
+        if ((def.type === 'boolean' || def.type === 'json') && def.default !== undefined) {
             flags[name] = def.default;
         }
         else if (def.type === 'boolean') {
@@ -76,16 +76,16 @@ exports.parse = function (definition, options) {
 
                 const opt = opts[j];
 
-                let objectDef;
+                let jsonDef;
 
                 if (opt.includes('.')) {
                     const maybeDef = keys[opt.split('.')[0]];
-                    if (maybeDef && maybeDef.type === 'object') {
-                        objectDef = maybeDef;
+                    if (maybeDef && maybeDef.type === 'json') {
+                        jsonDef = maybeDef;
                     }
                 }
 
-                const def = keys[opt] || objectDef;
+                const def = keys[opt] || jsonDef;
 
                 if (!def) {
                     errors.push(internals.formatError('Unknown option:', opt));
@@ -139,7 +139,7 @@ exports.parse = function (definition, options) {
                     continue;
                 }
 
-                if (last.def.type === 'object') {
+                if (last.def.type === 'json') {
 
                     const stringValue = value;
 
@@ -184,7 +184,7 @@ exports.parse = function (definition, options) {
 
                     flags[name].push(value);
                 }
-                else if (last.def.type === 'object') {
+                else if (last.def.type === 'json') {
                     Hoek.merge(flags[name], value);
                 }
                 else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,8 @@ const Tty = require('tty');
 
 const Boom = require('@hapi/boom');
 const Hoek = require('@hapi/hoek');
+const Bounce = require('@hapi/bounce');
+const Bourne = require('@hapi/bourne');
 const Validate = require('@hapi/validate');
 
 const Schemas = require('./schemas');
@@ -34,7 +36,7 @@ exports.parse = function (definition, options) {
             }
         }
 
-        if (def.type === 'boolean' && def.default !== undefined) {
+        if ((def.type === 'boolean' || def.type === 'object') && def.default !== undefined) {
             flags[name] = def.default;
         }
         else if (def.type === 'boolean') {
@@ -68,12 +70,23 @@ exports.parse = function (definition, options) {
             for (let j = 0; j < opts.length; ++j) {
 
                 if (last) {
-                    errors.push(internals.formatError('Invalid option:', last.name, 'missing value'));
+                    errors.push(internals.formatError('Invalid option:', last.def.name, 'missing value'));
                     continue;
                 }
 
                 const opt = opts[j];
-                const def = keys[opt];
+
+                let objectDef;
+
+                if (opt.includes('.')) {
+                    const maybeDef = keys[opt.split('.')[0]];
+                    if (maybeDef && maybeDef.type === 'object') {
+                        objectDef = maybeDef;
+                    }
+                }
+
+                const def = keys[opt] || objectDef;
+
                 if (!def) {
                     errors.push(internals.formatError('Unknown option:', opt));
                     continue;
@@ -90,11 +103,11 @@ exports.parse = function (definition, options) {
                     opts.length > 1) {
 
                     args.splice(i + 1, 0, arg.split(char)[1]);
-                    last = def;
+                    last = { def, opt };
                     break;
                 }
                 else {
-                    last = def;
+                    last = { def, opt };
                 }
             }
         }
@@ -104,36 +117,64 @@ exports.parse = function (definition, options) {
 
             let value = arg;
             if (last) {
-                if (last.type === 'number') {
+                if (last.def.type === 'number') {
                     value = parseInt(arg, 10);
 
                     if (!Number.isSafeInteger(value)) {
-                        errors.push(internals.formatError('Invalid value (non-number) for option:', last.name));
+                        errors.push(internals.formatError('Invalid value (non-number) for option:', last.def.name));
                         continue;
                     }
                 }
 
-                if (last.valid &&
-                    last.valid.indexOf(value) === -1) {
+                if (last.def.valid &&
+                    !last.def.valid.includes(value)) {
 
                     const validValues = [];
-                    for (let j = 0; j < last.valid.length; ++j) {
-                        const valid = last.valid[j];
+                    for (let j = 0; j < last.def.valid.length; ++j) {
+                        const valid = last.def.valid[j];
                         validValues.push(`'${valid}'`);
                     }
 
-                    errors.push(internals.formatError('Invalid value for option:', last.name, '(valid: ' + validValues.join(',') + ')'));
+                    errors.push(internals.formatError('Invalid value for option:', last.def.name, '(valid: ' + validValues.join(',') + ')'));
                     continue;
+                }
+
+                if (last.def.type === 'object') {
+
+                    try {
+                        value = Bourne.parse(value, {   // E.g. { x }
+                            protoAction: 'remove'
+                        });
+                    }
+                    catch (err) {
+                        Bounce.ignore(err, SyntaxError);
+                    }
+
+                    last.opt.split('.')                 // E.g. [name, lvl1, lvl2]
+                        .slice(1)                       // E.g. [lvl1, lvl2]
+                        .reverse()                      // E.g. [lvl2, lvl1]
+                        .forEach((key) => {             // E.g. { x } --> { lvl2: { x } } --> { lvl1: { lvl2: { x } } }
+
+                            value = { [key]: value };
+                        });
+
+                    if (!value || typeof value !== 'object') {
+                        errors.push(internals.formatError('Invalid value for option:', last.def.name, '(must be an object or array)'));
+                        continue;
+                    }
                 }
             }
 
-            const name = last ? last.name : '_';
+            const name = last ? last.def.name : '_';
             if (flags.hasOwnProperty(name)) {
 
                 if (!last ||
-                    last.multiple) {
+                    last.def.multiple) {
 
                     flags[name].push(value);
+                }
+                else if (last.def.type === 'object') {
+                    Hoek.merge(flags[name], value);
                 }
                 else {
                     errors.push(internals.formatError('Multiple values are not allowed for option:', name));
@@ -142,7 +183,7 @@ exports.parse = function (definition, options) {
             }
             else {
                 if (!last ||
-                    last.multiple) {
+                    last.def.multiple) {
 
                     flags[name] = [].concat(value);
                 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -149,11 +149,23 @@ exports.parse = function (definition, options) {
                         });
                     }
                     catch (err) {
-                        // If the input doesn't look like JSON, we'll ignore that and treat it as a string
+                        // If the input doesn't look like JSON, we'll ignore that
+                        // and treat it as a string, unless parsePrimitives is 'strict'
                         Bounce.ignore(err, SyntaxError);
+                        if (last.def.parsePrimitives === 'strict') {
+                            errors.push(internals.formatError('Invalid value for option:', last.opt, '(invalid JSON)'));
+                            continue;
+                        }
                     }
 
-                    if (!last.def.parsePrimitives && (!value || typeof value !== 'object')) {
+                    const isPrimitive = !value || typeof value !== 'object';
+
+                    if (last.def.parsePrimitives === 'strict' && !isPrimitive) {
+                        errors.push(internals.formatError('Invalid value for option:', last.opt, '(non-primitive JSON value)'));
+                        continue;
+                    }
+
+                    if (!last.def.parsePrimitives && isPrimitive) {
                         // When receiving JSON that parses to a non-object, treat it as a string, i.e. numbers, true, false, null.
                         value = stringValue;
                     }

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -18,7 +18,9 @@ exports.definition = Validate.object({}).pattern(internals.validKeyRegex, Valida
     default: Validate.any()
         .when('type', { is: 'object', then: [Validate.array(), Validate.object()] }),
     valid: Validate.array().items(Validate.any()).single()
-        .when('type', { is: 'object', then: Validate.forbidden() })
+        .when('type', { is: 'object', then: Validate.forbidden() }),
+    parsePrimitives: Validate.boolean()
+        .when('type', { is: 'object', otherwise: Validate.forbidden() })
 }));
 
 

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -19,7 +19,7 @@ exports.definition = Validate.object({}).pattern(internals.validKeyRegex, Valida
         .when('type', { is: 'json', then: [Validate.array(), Validate.object()] }),
     valid: Validate.array().items(Validate.any()).single()
         .when('type', { is: 'json', then: Validate.forbidden() }),
-    parsePrimitives: Validate.boolean()
+    parsePrimitives: Validate.boolean().allow('strict')
         .when('type', { is: 'json', otherwise: Validate.forbidden() })
 }), { fallthrough: true })
     .pattern(/\./, Validate.object({ type: Validate.invalid('json') }));

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -10,17 +10,17 @@ const internals = {
 
 exports.definition = Validate.object({}).pattern(internals.validKeyRegex, Validate.object({
     alias: Validate.array().items(Validate.string().allow('')).single(),
-    type: Validate.string().valid('object', 'boolean', 'range', 'number', 'string', 'help').default('string'),
+    type: Validate.string().valid('json', 'boolean', 'range', 'number', 'string', 'help').default('string'),
     multiple: Validate.boolean()
-        .when('type', { is: 'object', then: Validate.forbidden() }),
+        .when('type', { is: 'json', then: Validate.forbidden() }),
     description: Validate.string(),
     require: Validate.boolean(),
     default: Validate.any()
-        .when('type', { is: 'object', then: [Validate.array(), Validate.object()] }),
+        .when('type', { is: 'json', then: [Validate.array(), Validate.object()] }),
     valid: Validate.array().items(Validate.any()).single()
-        .when('type', { is: 'object', then: Validate.forbidden() }),
+        .when('type', { is: 'json', then: Validate.forbidden() }),
     parsePrimitives: Validate.boolean()
-        .when('type', { is: 'object', otherwise: Validate.forbidden() })
+        .when('type', { is: 'json', otherwise: Validate.forbidden() })
 }));
 
 

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -10,12 +10,15 @@ const internals = {
 
 exports.definition = Validate.object({}).pattern(internals.validKeyRegex, Validate.object({
     alias: Validate.array().items(Validate.string().allow('')).single(),
-    type: Validate.string().valid('boolean', 'range', 'number', 'string', 'help').default('string'),
-    multiple: Validate.boolean(),
+    type: Validate.string().valid('object', 'boolean', 'range', 'number', 'string', 'help').default('string'),
+    multiple: Validate.boolean()
+        .when('type', { is: 'object', then: Validate.forbidden() }),
     description: Validate.string(),
     require: Validate.boolean(),
-    default: Validate.any(),
+    default: Validate.any()
+        .when('type', { is: 'object', then: [Validate.array(), Validate.object()] }),
     valid: Validate.array().items(Validate.any()).single()
+        .when('type', { is: 'object', then: Validate.forbidden() })
 }));
 
 

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -4,7 +4,7 @@ const Validate = require('@hapi/validate');
 
 
 const internals = {
-    validKeyRegex: /^[a-zA-Z0-9][a-zA-Z0-9-]*$/
+    validKeyRegex: /^[a-zA-Z0-9][a-zA-Z0-9-\.]*$/
 };
 
 
@@ -21,7 +21,8 @@ exports.definition = Validate.object({}).pattern(internals.validKeyRegex, Valida
         .when('type', { is: 'json', then: Validate.forbidden() }),
     parsePrimitives: Validate.boolean()
         .when('type', { is: 'json', otherwise: Validate.forbidden() })
-}));
+}), { fallthrough: true })
+    .pattern(/\./, Validate.object({ type: Validate.invalid('json') }));
 
 
 exports.parseOptions = Validate.object({

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   ],
   "dependencies": {
     "@hapi/boom": "9.x.x",
+    "@hapi/bounce": "2.x.x",
+    "@hapi/bourne": "2.x.x",
     "@hapi/hoek": "9.x.x",
     "@hapi/validate": "1.x.x"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -433,6 +433,19 @@ describe('parse()', () => {
         expect(argv).to.equal({ x: { y: 1 } });
     });
 
+    it('protects from prototype poisoning in dot separated object path', () => {
+
+        const line = '--x.__proto__.y 1 --x.z 2 --x.__proto__.w 3';
+        const definition = {
+            x: {
+                type: 'object'
+            }
+        };
+
+        const argv = parse(line, definition);
+        expect(argv).to.equal({ x: { z: 2 } });
+    });
+
     it('allows custom argv to be passed in options in place of process.argv', () => {
 
         let argv = ['-a', '1-2,5'];

--- a/test/index.js
+++ b/test/index.js
@@ -63,7 +63,7 @@ describe('parse()', () => {
                 alias: 'H'
             },
             i: {
-                type: 'object',
+                type: 'json',
                 default: { x: 1, w: 3 }
             }
         };
@@ -305,12 +305,12 @@ describe('parse()', () => {
         expect(argv).to.equal({ a: null, _: [''] });
     });
 
-    it('allows an object to be built from JSON, parsing primitives.', () => {
+    it('allows json to build an object, parsing primitives.', () => {
 
         const line = ['--x', '{ "a": null, "b": { "c": 2 } }', '--x.b.d', '3', '--x.e', '["four"]', '--x.f', 'false', '--x.g', 'null'];
         const definition = {
             x: {
-                type: 'object',
+                type: 'json',
                 parsePrimitives: true
             }
         };
@@ -319,12 +319,12 @@ describe('parse()', () => {
         expect(argv).to.equal({ x: { a: null, b: { c: 2, d: 3 }, e: ['four'], f: false, g: null } });
     });
 
-    it('allows an object to be built from JSON, not parsing primitives.', () => {
+    it('allows json to build an object, not parsing primitives.', () => {
 
         const line = ['--x', '{ "a": null, "b": { "c": 2 } }', '--x.b.d', '3', '--x.e', '["four"]', '--x.f', 'false', '--x.g', 'null'];
         const definition = {
             x: {
-                type: 'object',
+                type: 'json',
                 parsePrimitives: false
             }
         };
@@ -333,12 +333,12 @@ describe('parse()', () => {
         expect(argv).to.equal({ x: { a: null, b: { c: 2, d: '3' }, e: ['four'], f: 'false', g: 'null' } });
     });
 
-    it('allows an object to be built, by default not parsing primitives.', () => {
+    it('allows json to build an object, by default not parsing primitives.', () => {
 
         const line = '--x.a null --x.b 2 --x.c true --x.d false --x.e str';
         const definition = {
             x: {
-                type: 'object'
+                type: 'json'
             }
         };
 
@@ -346,12 +346,12 @@ describe('parse()', () => {
         expect(argv).to.equal({ x: { a: 'null', b: '2', c: 'true', d: 'false', e: 'str' } });
     });
 
-    it('merges into object defaults', () => {
+    it('merges into json object defaults', () => {
 
         const line = ['--x.b', 'two', '--x', '{ "c": 3 }'];
         const definition = {
             x: {
-                type: 'object',
+                type: 'json',
                 default: { a: 1, b: 4 }
             }
         };
@@ -361,7 +361,7 @@ describe('parse()', () => {
         expect(definition.x.default).to.equal({ a: 1, b: 4 }); // No mutation of defaults despite merge
     });
 
-    it('only sets object arg types deeply', () => {
+    it('only sets json arg types deeply', () => {
 
         const line = '--a.b str';
         const definition = {
@@ -375,11 +375,11 @@ describe('parse()', () => {
         expect(argv.message).to.contain('Unknown option: a.b');
     });
 
-    it('requires object args be objects', () => {
+    it('requires json args be objects', () => {
 
         const definition = {
             a: {
-                type: 'object',
+                type: 'json',
                 parsePrimitives: true
             }
         };
@@ -395,12 +395,12 @@ describe('parse()', () => {
         expect(argv2.message).to.contain('Invalid value for option: a (must be an object or array)');
     });
 
-    it('handles missing arg for object-looking option', () => {
+    it('handles missing arg for json-looking option', () => {
 
         const line = '--y.z str';
         const definition = {
             x: {
-                type: 'object'
+                type: 'json'
             }
         };
 
@@ -409,11 +409,11 @@ describe('parse()', () => {
         expect(argv.message).to.contain('Unknown option: y.z');
     });
 
-    it('requires object arg default be an array or object', () => {
+    it('requires json arg default be an array or object', () => {
 
         const definition = (def) => ({
             x: {
-                type: 'object',
+                type: 'json',
                 default: def
             }
         });
@@ -425,11 +425,11 @@ describe('parse()', () => {
         expect(() => parse('', definition(100))).to.throw(/must be one of \[array, object\]/);
     });
 
-    it('does not allow passing valid option for object args', () => {
+    it('does not allow passing valid option for json args', () => {
 
         const definition = {
             x: {
-                type: 'object',
+                type: 'json',
                 valid: { x: 1 }
             }
         };
@@ -437,11 +437,11 @@ describe('parse()', () => {
         expect(() => parse('', definition)).to.throw(/"x\.valid" is not allowed/);
     });
 
-    it('does not allow passing multiple option for object args', () => {
+    it('does not allow passing multiple option for json args', () => {
 
         const definition = {
             x: {
-                type: 'object',
+                type: 'json',
                 multiple: true
             }
         };
@@ -449,7 +449,7 @@ describe('parse()', () => {
         expect(() => parse('', definition)).to.throw(/"x\.multiple" is not allowed/);
     });
 
-    it('does not allow passing parsePrimitives option for non-object args', () => {
+    it('does not allow passing parsePrimitives option for non-json args', () => {
 
         const definition = {
             x: {
@@ -461,12 +461,12 @@ describe('parse()', () => {
         expect(() => parse('', definition)).to.throw(/"x\.parsePrimitives" is not allowed/);
     });
 
-    it('protects from prototype poisoning when parsing JSON for object args', () => {
+    it('protects from prototype poisoning when parsing JSON for json args', () => {
 
         const line = ['--x', '{ "y": 1, "__proto__": { "z": 2 } }'];
         const definition = {
             x: {
-                type: 'object'
+                type: 'json'
             }
         };
 
@@ -474,12 +474,12 @@ describe('parse()', () => {
         expect(argv).to.equal({ x: { y: 1 } });
     });
 
-    it('protects from prototype poisoning in dot-separated object path', () => {
+    it('protects from prototype poisoning in dot-separated json path', () => {
 
         const line = '--x.__proto__.y one --x.z two --x.__proto__.w three';
         const definition = {
             x: {
-                type: 'object'
+                type: 'json'
             }
         };
 


### PR DESCRIPTION
This PR implements the the ability to have an object-type argument so that the user can build-up an object value using dot-separated paths and JSON.  For example, an object argument named `pet` might be built from `--pet '{ "type": "dog" }' --pet.name Maddie`, resulting in the parsing output `{ pet: { type: 'dog', name: 'Maddie' } }`.  Comparable functionality can be found in other arg parsers such as yargs.

I am not sure if this may be applicable within lab, but if this lands I believe yargs can be removed from [confidence](https://github.com/hapipal/confidence), and will simplify some code in [hpal-debug](https://github.com/hapipal/hpal-debug) as well, which would be useful to hapi pal.  I believe this could also open-up some possibilities, e.g. to build request payloads from the command line.