### PR TITLE
Fix display of defaults for json args and zero

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -293,9 +293,11 @@ exports.usage = function (definition, usage, options) {
         }
 
         let formattedDesc = def.description ? color.gray(def.description) : '';
-        if (def.default) {
+        if (def.default || def.default === 0) {
             formattedDesc += formattedDesc.length ? ' ' : '';
-            formattedDesc += color.gray('(' + def.default + ')');
+            formattedDesc += def.type === 'json' ?
+                color.gray('(' + JSON.stringify(def.default) + ')') :
+                color.gray('(' + def.default + ')');
         }
 
         if (def.require) {

--- a/test/index.js
+++ b/test/index.js
@@ -1114,8 +1114,15 @@ describe('usage()', () => {
             },
             d: {
                 alias: ['']
+            },
+            e: {
+                type: 'number',
+                default: 0
+            },
+            f: {
+                type: 'json',
+                default: { x: 'y', z: 1 }
             }
-
         };
 
         const result = Bossy.usage(definition);
@@ -1124,6 +1131,10 @@ describe('usage()', () => {
         expect(result).to.contain('(b)');
         expect(result).to.contain('-c, --code');
         expect(result).to.contain('(c)');
+        expect(result).to.contain('-e');
+        expect(result).to.contain('(0)');
+        expect(result).to.contain('-f');
+        expect(result).to.contain('({"x":"y","z":1})');
     });
 });
 


### PR DESCRIPTION
After using #77 I found that JSON arg defaults displayed as `[object Object]` when output in usage via `Bossy.usage()`.  This PR fixes that, instead displaying the default as stringified JSON.  While working on this I noticed that a default of `0` wouldn't display, so I have fixed that too and added tests that would have caught these issues.