### PR TITLE
Support node v18 and drop node v12

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -3,6 +3,7 @@ name: ci
 on:
   push:
     branches:
+      - v6
       - master
   pull_request:
   workflow_dispatch:
@@ -10,3 +11,5 @@ on:
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-module.yml@master
+    with:
+      min-node-version: 14

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2014-2021, Project contributors
+Copyright (c) 2014-2022, Project contributors
 Copyright (c) 2014-2020, Sideway Inc
 Copyright (c) 2014, Walmart.
 All rights reserved.

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,7 +44,7 @@ exports.parse = function (definition, options) {
         }
     }
 
-    const args = options.argv || process.argv.slice(2);
+    const args = options.argv ?? process.argv.slice(2);
     let last = null;
     const errors = [];
     let help = false;
@@ -80,7 +80,7 @@ exports.parse = function (definition, options) {
 
                 if (opt.startsWith('no-')) {
                     const maybeDef = keys[opt.replace('no-', '')];
-                    if (maybeDef && maybeDef.type === 'boolean') {
+                    if (maybeDef?.type === 'boolean') {
                         booleanNegationDef = maybeDef;
                     }
                 }
@@ -89,12 +89,12 @@ exports.parse = function (definition, options) {
 
                 if (opt.includes('.')) {
                     const maybeDef = keys[opt.split('.')[0]];
-                    if (maybeDef && maybeDef.type === 'json') {
+                    if (maybeDef?.type === 'json') {
                         jsonDef = maybeDef;
                     }
                 }
 
-                const def = keys[opt] || booleanNegationDef || jsonDef;
+                const def = keys[opt] ?? booleanNegationDef ?? jsonDef;
 
                 if (!def) {
                     errors.push(internals.formatError('Unknown option:', opt));

--- a/package.json
+++ b/package.json
@@ -19,16 +19,16 @@
     ]
   },
   "dependencies": {
-    "@hapi/boom": "9.x.x",
-    "@hapi/bounce": "2.x.x",
-    "@hapi/bourne": "2.x.x",
-    "@hapi/hoek": "9.x.x",
-    "@hapi/validate": "1.x.x"
+    "@hapi/boom": "^10.0.0",
+    "@hapi/bounce": "^3.0.0",
+    "@hapi/bourne": "^3.0.0",
+    "@hapi/hoek": "^10.0.0",
+    "@hapi/validate": "^1.0.0"
   },
   "devDependencies": {
-    "@hapi/code": "8.x.x",
+    "@hapi/code": "^9.0.0",
     "@hapi/eslint-plugin": "*",
-    "@hapi/lab": "24.x.x"
+    "@hapi/lab": "25.0.0-beta.1"
   },
   "scripts": {
     "test": "lab -a @hapi/code -t 100 -L",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@hapi/bounce": "^3.0.0",
     "@hapi/bourne": "^3.0.0",
     "@hapi/hoek": "^10.0.0",
-    "@hapi/validate": "^1.0.0"
+    "@hapi/validate": "^2.0.0"
   },
   "devDependencies": {
     "@hapi/code": "^9.0.0",


### PR DESCRIPTION
 - Test on node v14+ and adopt some new syntax.
 - Update to node v18-compatible versions of boom, bounce, bourne, hoek, code, lab, and (pending) validate.

If this looks good, this will go out as bossy v6.